### PR TITLE
Sort SQL upgrade script versions numerically

### DIFF
--- a/install_kuali_coeus
+++ b/install_kuali_coeus
@@ -478,7 +478,7 @@ function exec_sql_scripts() {
 	echo
 	if [ "$mysql_or_oracle" -eq "1" ]; then
 		cd ${MYSQL_SQL_FILES_FOLDER}
-		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq ) )
+		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq | sort -n) )
 		for version in ${INSTALL_SQL_VERSION[@]:${1}}
 		do
 			# INSTALL THE MYSQL FILES
@@ -511,7 +511,7 @@ function exec_sql_scripts() {
 		fi
 	elif [ "$mysql_or_oracle" -eq "2" ]; then
 		cd ${ORACLE_SQL_FILES_FOLDER}
-		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq ) )
+		INSTALL_SQL_VERSION=( $(ls -v *.sql | grep -v INSTALL_TEMPLATE | sed 's/_.*//g' | uniq | sort -n) )
 		for version in ${INSTALL_SQL_VERSION[@]:${1}}
 		do
 			# INSTALL THE MYSQL FILES


### PR DESCRIPTION
Modified script to sort SQL upgrade version scripts by their numeric value instead of as text. This ensures SQL upgrade versions are applied in the correct order (version 001, 300, 301, ... 600, 601, 602, 1505,1506,1507). Without this numeric sort, scripts are sorted as text string values (version 001, 1505, 1506, 1507, 300, 301,...) causing some scripts to be applied out of order and resulting in errors. 
